### PR TITLE
Implement metadata.json parsing in osc-plugin-qam

### DIFF
--- a/oscqam/actions/approveuseraction.py
+++ b/oscqam/actions/approveuseraction.py
@@ -22,13 +22,11 @@ class ApproveUserAction(ApproveAction):
     def validate(self):
         """Check preconditions to be met before a request can be approved.
 
-        :raises: :class:`oscqam.models.TestResultMismatchError` or
-        :class:`oscqam.models.TestPlanReviewerNotSetError` if conditions
+        :raises: :class:`oscqam.models.TestResultMismatchError` if conditions
         are not met.
 
         """
         self.reviews_assigned()
-        self.template.testplanreviewer()
         self.template.passed()
 
     def additional_reviews(self):
@@ -37,7 +35,7 @@ class ApproveUserAction(ApproveAction):
 
     def action(self):
         self.validate()
-        url = self.template.fancy_url()
+        url = self.template.fancy_url
         groups = ", ".join([str(g) for g in self.user.in_review_groups(self.request)])
         msg = self.APPROVE_MSG.format(
             user=self.reviewer, groups=groups, request=self.request, url=url

--- a/oscqam/actions/rejectaction.py
+++ b/oscqam/actions/rejectaction.py
@@ -31,8 +31,7 @@ class RejectAction(OscAction):
     def validate(self):
         """Check preconditions to be met before a request can be approved.
 
-        :raises: :class:`oscqam.models.TestResultMismatchError` or
-            :class:`oscqam.models.TestPlanReviewerNotSetError` if conditions
+        :raises: :class:`oscqam.models.TestResultMismatchError` if conditions
             are not met.
 
         """
@@ -42,7 +41,7 @@ class RejectAction(OscAction):
 
     def action(self):
         self.validate()
-        url = self.template.fancy_url()
+        url = self.template.fancy_url
         msg = RejectAction.DECLINE_MSG.format(
             user=self.user, request=self.request, url=url
         )

--- a/oscqam/errors.py
+++ b/oscqam/errors.py
@@ -17,6 +17,8 @@ class NoQamReviewsError(UninferableError):
     def __init__(self, accepted_reviews):
         """Create new error for accepted reviews."""
         message = "No 'qam'-groups need review."
+        from oscqam.models.review import GroupReview
+
         accept_reviews = [
             review for review in accepted_reviews if isinstance(review, GroupReview)
         ]
@@ -32,7 +34,7 @@ class NoQamReviewsError(UninferableError):
             if accept_reviews
             else ""
         )
-        super(NoQamReviewsError, self).__init__(message)
+        super().__init__(message)
 
 
 class NonMatchingGroupsError(UninferableError):
@@ -46,7 +48,7 @@ class NonMatchingGroupsError(UninferableError):
             eg=[g.name for g in expected_groups],
             fg=[r.name for r in found_groups],
         )
-        super(NonMatchingGroupsError, self).__init__(message)
+        super().__init__(message)
 
 
 class NonMatchingUserGroupsError(UninferableError):
@@ -66,7 +68,7 @@ class NonMatchingUserGroupsError(UninferableError):
             ug=[g.name for g in user_groups],
             og=[r.name for r in open_groups],
         )
-        super(NonMatchingUserGroupsError, self).__init__(message)
+        super().__init__(message)
 
 
 class InvalidRequestError(ReportedError):
@@ -82,7 +84,7 @@ class MissingSourceProjectError(InvalidRequestError):
     """Raise when a request is missing the source project property."""
 
     def __init__(self, request):
-        super(MissingSourceProjectError, self).__init__(
+        super().__init__(
             "Invalid build service request: "
             "{0} has no source project.".format(request)
         )
@@ -92,25 +94,14 @@ class TemplateNotFoundError(ReportedError):
     """Raise when a template could not be found."""
 
     def __init__(self, message):
-        super(TemplateNotFoundError, self).__init__(
-            "Report could not be loaded: {0}".format(message)
-        )
+        super().__init__("Report could not be loaded: {0}".format(message))
 
 
 class TestResultMismatchError(ReportedError):
     _msg = "Request-Status not '{0}': please check report: {1}"
 
     def __init__(self, expected, log_path):
-        super(TestResultMismatchError, self).__init__(
-            self._msg.format(expected, log_path)
-        )
-
-
-class TestPlanReviewerNotSetError(ReportedError):
-    _msg = "The testreport ({path}) is missing a test plan reviewer."
-
-    def __init__(self, path):
-        super(TestPlanReviewerNotSetError, self).__init__(self._msg.format(path=path))
+        super().__init__(self._msg.format(expected, log_path))
 
 
 class ActionError(ReportedError):
@@ -127,9 +118,7 @@ class NoReviewError(UninferableError):
     """
 
     def __init__(self, user):
-        super(NoReviewError, self).__init__(
-            "User {u} is not assigned for any groups.".format(u=user)
-        )
+        super().__init__("User {u} is not assigned for any groups.".format(u=user))
 
 
 class MultipleReviewsError(UninferableError):
@@ -139,7 +128,7 @@ class MultipleReviewsError(UninferableError):
     """
 
     def __init__(self, user, groups):
-        super(MultipleReviewsError, self).__init__(
+        super().__init__(
             "User {u} is currently reviewing for mulitple groups: {g}."
             "Please provide which group to unassign via -G parameter.".format(
                 u=user, g=groups
@@ -155,7 +144,7 @@ class ReportNotYetGeneratedError(ReportedError):
     )
 
     def __init__(self, request):
-        super(ReportNotYetGeneratedError, self).__init__(self._msg.format(str(request)))
+        super().__init__(self._msg.format(str(request)))
 
 
 class OneGroupAssignedError(ReportedError):
@@ -166,7 +155,7 @@ class OneGroupAssignedError(ReportedError):
     )
 
     def __init__(self, assignment):
-        super(OneGroupAssignedError, self).__init__(
+        super().__init__(
             self._msg.format(user=str(assignment.user), group=str(assignment.group))
         )
 
@@ -178,9 +167,7 @@ class NotPreviousReviewerError(ReportedError):
     )
 
     def __init__(self, reviewers):
-        super(NotPreviousReviewerError, self).__init__(
-            self._msg.format(reviewers=reviewers)
-        )
+        super().__init__(self._msg.format(reviewers=reviewers))
 
 
 class NoCommentError(ReportedError):
@@ -189,11 +176,11 @@ class NoCommentError(ReportedError):
     )
 
     def __init__(self):
-        super(NoCommentError, self).__init__(self._msg)
+        super().__init__(self._msg)
 
 
 class NotAssignedError(ReportedError):
     _msg = "The user {user} is not assigned to this update."
 
     def __init__(self, user):
-        super(NotAssignedError, self).__init__(self._msg.format(user=user))
+        super().__init__(self._msg.format(user=user))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -19,7 +19,7 @@ from oscqam.models import (
 from oscqam.reject_reasons import RejectReason
 
 from .mockremote import MockRemote
-from .utils import create_template_data, load_fixture
+from .utils import FakeTrGetter, create_template_data, load_fixture
 
 
 comment_1_xml = load_fixture("comments_1.xml")
@@ -50,7 +50,7 @@ def create_template(request_data=None, template_data=None):
     if not template_data:
         template_data = template_txt
     request = Request.parse(MockRemote(), request_data)[0]
-    template = Template(request, tr_getter=lambda x: template_data)
+    template = Template(request, tr_getter=FakeTrGetter(template_data))
     return template
 
 
@@ -327,17 +327,6 @@ def test_obs27_workaround_post_152(remote):
 def test_request_str(remote):
     request = Request.parse(remote, req_1_xml)[0]
     assert str(request) == "12345"
-
-
-def test_test_plan_reviewer():
-    reviewer_singular = create_template(
-        template_data=create_template_data(**{"Test Plan Reviewer": "a"})
-    )
-    reviewer_plural = create_template(
-        template_data=create_template_data(**{"Test Plan Reviewers": "a"})
-    )
-    assert reviewer_singular.testplanreviewer() == "a"
-    assert reviewer_plural.testplanreviewer() == "a"
 
 
 def test_parse_comment(remote):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -21,3 +21,12 @@ def create_template_data(**data):
     if TemplateParser.end_marker not in data.keys():
         data[TemplateParser.end_marker] = ""
     return "\n".join(": ".join(v) for v in (zip(data.keys(), data.values())))
+
+
+class FakeTrGetter:
+    def __init__(self, tmpl, meta=None) -> None:
+        self.tmpl = tmpl
+        self.meta = meta
+
+    def __call__(self, *args, **kwds):
+        return (self.tmpl, self.meta)


### PR DESCRIPTION
Drop mandatory request on testreport reviewer
and try read metadata.json file from testrepository.

Made property from `Template.{url,fancy_url,metadata_url}`