### PR TITLE
actions: Correctly check previews reviewer

### DIFF
--- a/oscqam/actions/assignaction.py
+++ b/oscqam/actions/assignaction.py
@@ -65,9 +65,13 @@ class AssignAction(OscAction):
         ]
         if not declined_requests:
             return
+        rejects = [
+            request
+            for request in declined_requests
+        ][0]
         reviewers = [
             review.reviewer
-            for review in (request.review_list() for request in declined_requests)
+            for review in rejects.review_list()
             if isinstance(review, UserReview)
         ]
         if self.user not in reviewers:

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -344,8 +344,6 @@ def test_assign_previous_reject_not_old_reviewer(remote):
         assign()
 
 
-# TODO: FIX thix
-@pytest.mark.skip("Broken test - maybe wrong fixture")
 def test_assign_previous_reject_old_reviewer(remote):
     out = StringIO()
     remote.register_url(
@@ -399,8 +397,6 @@ def test_assign_previous_reject_not_old_reviewer_force(remote):
     )
 
 
-# TODO: FIX thix
-@pytest.mark.skip("Broken test - maybe wrong fixture")
 def test_assign_skip_template(remote):
     """Assign a request without a testreport template."""
     out = StringIO()


### PR DESCRIPTION
The fix feels wrong. It makes two tests pass that were marked as broken. Either there's a bug that nobody noticed because the check would never have worked. Or there's something in the test that I don't understand.

See: https://progress.opensuse.org/issues/104781