### PR TITLE
fix(report): derive SLFO staging report RRID from the target project

### DIFF
--- a/oscqam/models/request.py
+++ b/oscqam/models/request.py
@@ -166,14 +166,25 @@ class Request(osc.core.Request, XmlFactoryMixin):
         This is a special version for requests that are submitted to a
         staging project first.
 
+        For SLFO staging requests (source is a home/staging project, target
+        is SUSE:SLFO:*) the RRID is derived from the target project so that
+        the correct report URL is generated (e.g. SUSE:SLFO:1.1:<reqid>).
+
         Returns:
             The source project name for the PI request.
         """
         for action in self.actions:
             if hasattr(action, "src_project"):
                 prj = action.src_project
+                tgt = getattr(action, "tgt_project", None) or ""
                 if prj:
+                    if tgt.startswith("SUSE:SLFO:"):
+                        # SLFO staging request: report lives under the target
+                        # project, e.g. SUSE:SLFO:1.1:<reqid>/log
+                        return tgt
                     if prj.startswith("SUSE:SLFO:"):
+                        # PI / product release: source IS the SLFO project;
+                        # derive the version component for SUSE:PI:<ver>
                         ver = prj.split(":")[-2]
                         return f"SUSE:PI:{ver}"
                     return prj

--- a/tests/fixtures/request_slfo_pi.xml
+++ b/tests/fixtures/request_slfo_pi.xml
@@ -1,0 +1,11 @@
+<request id="415655">
+  <action type="release">
+    <source project="SUSE:SLFO:Products:SLES:16.0:TEST" package="patchinfo"/>
+    <target project="SUSE:Products:SLE-Product-SLES:16.0:aarch64" package="patchinfo"/>
+  </action>
+  <review state="new" when="2024-11-14T11:12:53" who="anonymous" by_group="qam-sle">
+  </review>
+  <state name="review" who="anonymous" when="2024-12-01T14:46:23">
+    <comment>In review</comment>
+  </state>
+</request>

--- a/tests/fixtures/request_slfo_staging.xml
+++ b/tests/fixtures/request_slfo_staging.xml
@@ -1,0 +1,11 @@
+<request id="415080">
+  <action type="submit">
+    <source project="home:gsonnu:slfo-patchinfos" package="docker"/>
+    <target project="SUSE:SLFO:1.1" package="docker"/>
+  </action>
+  <review state="new" when="2024-11-14T11:12:53" who="anonymous" by_group="qam-sle">
+  </review>
+  <state name="review" who="anonymous" when="2024-12-01T14:46:23">
+    <comment>In review</comment>
+  </state>
+</request>

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -38,6 +38,8 @@ req_invalid = load_fixture("request_no_src.xml")
 req_sle11sp4 = load_fixture("request_sle11sp4.xml")
 req_qam_auto = load_fixture("request_qam_auto.xml")
 req_two_assign = load_fixture("request_twoassign.xml")
+req_slfo_staging = load_fixture("request_slfo_staging.xml")
+req_slfo_pi = load_fixture("request_slfo_pi.xml")
 template_txt = load_fixture("template.txt")
 template_rh = load_fixture("template_rh.txt")
 user_txt = load_fixture("person_anonymous.xml")
@@ -131,6 +133,48 @@ def test_parse_request_id():
     test_id = "SUSE:Maintenance:123:45678"
     req_id = Request.parse_request_id(test_id)
     assert req_id == "45678"
+
+
+def test_src_project_to_rrid_classic_maintenance(remote):
+    """Classic maintenance requests return the source project verbatim."""
+    request = Request.parse(remote, req_1_xml)[0]
+    assert request.src_project_to_rrid == "SUSE:Maintenance:130"
+
+
+def test_src_project_to_rrid_slfo_staging(remote):
+    """SLFO staging requests (home:*:slfo-patchinfos → SUSE:SLFO:1.1) must
+    resolve the RRID from the TARGET project so the report URL is correct."""
+    request = Request.parse(remote, req_slfo_staging)[0]
+    assert request.src_project_to_rrid == "SUSE:SLFO:1.1"
+
+
+def test_src_project_to_rrid_slfo_pi(remote):
+    """SLFO PI/product-release requests (source IS SUSE:SLFO:*) keep the
+    existing SUSE:PI:<ver> mapping."""
+    request = Request.parse(remote, req_slfo_pi)[0]
+    assert request.src_project_to_rrid == "SUSE:PI:16.0"
+
+
+def test_template_url_slfo_staging(remote):
+    """Template.url for an SLFO staging request must point to
+    testreports/SUSE:SLFO:1.1:<reqid>/log, not the staging home project."""
+    request = Request.parse(remote, req_slfo_staging)[0]
+    template = Template(request, tr_getter=FakeTrGetter(template_txt))
+    assert template.url == "https://qam.suse.de/testreports/SUSE:SLFO:1.1:415080/log"
+
+
+def test_template_url_classic_maintenance(remote):
+    """Template.url for a classic maintenance request is unchanged."""
+    request = Request.parse(remote, req_1_xml)[0]
+    template = Template(request, tr_getter=FakeTrGetter(template_txt))
+    assert template.url == "https://qam.suse.de/testreports/SUSE:Maintenance:130:12345/log"
+
+
+def test_template_url_slfo_pi(remote):
+    """Template.url for an SLFO PI request keeps the SUSE:PI:<ver> mapping."""
+    request = Request.parse(remote, req_slfo_pi)[0]
+    template = Template(request, tr_getter=FakeTrGetter(template_txt))
+    assert template.url == "https://qam.suse.de/testreports/SUSE:PI:16.0:415655/log"
 
 
 def test_template_splits_srcrpms():

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -167,7 +167,9 @@ def test_template_url_classic_maintenance(remote):
     """Template.url for a classic maintenance request is unchanged."""
     request = Request.parse(remote, req_1_xml)[0]
     template = Template(request, tr_getter=FakeTrGetter(template_txt))
-    assert template.url == "https://qam.suse.de/testreports/SUSE:Maintenance:130:12345/log"
+    assert (
+        template.url == "https://qam.suse.de/testreports/SUSE:Maintenance:130:12345/log"
+    )
 
 
 def test_template_url_slfo_pi(remote):


### PR DESCRIPTION
## Problem

`Request.src_project_to_rrid` builds the test-report id from the request **source** project and only special-cases sources starting with `SUSE:SLFO:` (mapping them to `SUSE:PI:<ver>`).

An **SLFO:1.1 staging** request has:
- source = `home:<submitter>:slfo-patchinfos` (the patchinfo submission project)
- target = `SUSE:SLFO:1.1`

So the id fell through to the verbatim source and `template.py` built a bogus report URL `…/testreports/home:<submitter>:slfo-patchinfos:<reqid>/log` (HTTP 404), while the report actually exists at `…/testreports/SUSE:SLFO:1.1:<reqid>/log` (HTTP 200).

Impact (all via `Template(request)`):
- `qam assign` / `qam approve` / `qam reject` → false **"report not generated yet"** (and the error message even prints the wrong URL).
- `qam list` / `listassigned` / `info` → request **silently dropped** (`TemplateNotFoundError` swallowed in `ListAction`).

## Fix

In `src_project_to_rrid`, read the action's `tgt_project` and return it when it starts with `SUSE:SLFO:`, **before** the existing source-based PI mapping. This is the smallest correct change:

- **Staging** (src `home:*:slfo-patchinfos`, tgt `SUSE:SLFO:1.1`) → `SUSE:SLFO:1.1` → correct URL.
- **PI / product release** (src `SUSE:SLFO:*`, tgt `SUSE:Products:*`) → tgt guard skipped → existing `SUSE:PI:<ver>` mapping intact.
- **Classic Maintenance** → unchanged (source returned verbatim).

## Tests

Adds 6 tests + 2 fixtures covering staging, PI and classic Maintenance for both `src_project_to_rrid` and `Template.url`. Full suite: **98 passed, 6 skipped, 0 failed**.