### PR TITLE
docs: add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,86 @@
+# Agent Notes
+
+## Overview
+- `osc-plugin-qam` (package `oscqam`) is the **osc plugin** that powers the SUSE QA
+  Maintenance review workflow. It adds `osc qam <subcommand>` (`assign`, `approve`,
+  `reject`, `comment`, `info`, `list`, `my`, `unassign`, `rmcomment`, `assigned`,
+  `version`) on top of osc's request/review API to assign, sign off, and
+  approve/reject maintenance requests.
+- Two request backends: classic OBS/IBS requests dispatch through `osc`; SLFO
+  requests dispatch to **Gitea** pull requests. The plugin recognises which one is
+  in play from the request, not from a flag.
+- The library lives in `oscqam/`; the user-facing entry points are the thin osc
+  plugin wrappers `qam_*.py` installed to `/usr/lib/osc-plugins/`, each mapping to
+  one `osc qam <name>`.
+- PRs go to GitHub **`openSUSE/osc-plugin-qam`**, default branch **`master`**. The
+  package is built in IBS `QA:Maintenance`.
+
+## Setup & Commands
+- Setup (matches CI): `uv sync --locked`.
+- Make targets:
+  - `make typecheck` — `uv run ty check`
+  - `make only-test` — `uv run pytest`
+  - `make test-with-coverage` — pytest with `--cov=./oscqam` + junit/xml (what CI runs)
+  - `make checkstyle` — `uv run ruff format --check --diff ./`
+  - `make tidy` — `uv run ruff format ./` (auto-fix style)
+  - `make test` — `only-test` + `checkstyle`
+- Run as a user does: `osc qam --help` (the plugin must be on osc's plugin path;
+  see `Documentation/devel.rst`).
+
+## Testing
+- Pytest collects `tests/` (config in `[tool.pytest.ini_options]`). Request/template
+  XML fixtures live in `tests/fixtures/*.xml`; osc/HTTP interactions are stubbed in
+  the tests, never hitting the network.
+- Focus a test: `uv run pytest tests/test_model.py::test_name`.
+
+## Architecture (non-obvious bits)
+- `oscqam/actions/` — one `*Action` per operation (`assignaction`, `approveaction` /
+  `approveuseraction` / `approvegrpoupaction`, `rejectaction`, the `list*` family,
+  …), all subclassing `actions/oscaction.py`. The `oscqam/cli_*.py` modules wire each
+  osc subcommand to its action; the `/usr/lib/osc-plugins/qam_*.py` wrappers are the
+  osc entry points.
+- `oscqam/models/` — domain wrappers over `osc.core`:
+  - `request.py` (`Request`): note `src_project_to_rrid` derives the testreport RRID.
+    For SLFO **staging** requests the report id comes from the request's **target**
+    project (e.g. `SUSE:SLFO:1.1`), not the source project.
+  - `template.py` (`Template`): builds the `qam.suse.de/testreports/<rrid>/log`
+    machine/human report URLs. A wrong RRID here surfaces as a misleading
+    "report not generated yet" on assign/approve.
+  - plus `group`, `bug`, `comment`, `reviewer`, `assignment`, `filters`,
+    `requestfilters`.
+- Report/queue data comes from the QEM dashboard and `qam.suse.de`.
+
+## Type & Style
+- Supported Python is **3.9+** (`requires-python = ">=3.9"`); ruff
+  `target-version = "py39"`, `line-length = 88`; `ty` is pinned to `python-version =
+  "3.9"`. Keep code 3.9-compatible.
+- `make checkstyle` is `ruff format --check`, and CI lints the **whole repo
+  including `tests/`** — format `tests/` too. A tests-only formatting miss is the
+  most common way to red the pipeline.
+
+## Change Workflow
+- **Conventional Commits** are expected (`fix:`, `feat:`, `style:`, `build:`,
+  `ci:`, `docs:`…); reference SUSE Bugzilla as `bsc#NNNN` / `boo#NNNN`.
+- `ChangeLog.rst` is curated at **release time only** — do **not** add a per-PR
+  changelog entry (recent feature/fix PRs do not touch it).
+- Merge automation (`.mergify.yml`): an approved PR auto-merges once `base=master`,
+  all checks pass (`#check-failure=0`, `#check-pending=0`), history is linear, there
+  is `>=1` approval and no changes-requested. Hold a PR from auto-merge with the
+  **`not-ready`** (or `acceptance-tests-needed`) label; fast-track with `merge-fast`.
+
+## Definition of Done (hard rules)
+- Run the full gate on the **whole repo** (`./`) before pushing or claiming done:
+  `make typecheck` **and** `make test-with-coverage` **and** `make checkstyle`
+  (equivalently `uv run ty check`, `uv run pytest`, `uv run ruff format --check ./`).
+- "Done" means CI is **observed** green, not predicted — report status from the
+  actual run. Patch coverage is enforced via Codecov.
+- Rebase on `upstream/master` and keep history **linear** (mergify requires it).
+
+## External Dependencies
+- Driven through `osc` (`osc.core`) for OBS/IBS request/review actions and through the
+  Gitea API for SLFO pull requests. Source installs use `uv`, not PyPI.
+
+## Further Reading
+- `Documentation/devel.rst` — dev setup, the osc plugin path, and running the tests.
+- `README.rst` — user-facing overview and workflows.
+- `.mergify.yml` — merge automation rules referenced above.


### PR DESCRIPTION
Adds an `AGENTS.md` quick-reference for agents/contributors, aligned with the one in `openSUSE/mtui` and tailored to this repo.

Covers: overview (osc plugin, `osc qam <subcommand>`, osc vs Gitea backends, default branch `master`), setup + Make targets (`uv sync --locked`; `make typecheck`/`test-with-coverage`/`checkstyle`/`tidy`), testing (pytest + `tests/fixtures`), architecture (`actions/` + `cli_*.py` + `/usr/lib/osc-plugins/qam_*.py`; `models/request.py` `src_project_to_rrid` + `template.py` report URLs), type/style (Python 3.9+, ruff py39, ty 3.9; CI lints `tests/` too), change workflow (Conventional Commits; `ChangeLog.rst` curated at release only; `.mergify.yml` auto-merge + `not-ready` hold label), Definition of Done (whole-repo gate; CI observed green; linear history), and further reading.

Docs-only; no code/test changes.