### PR TITLE
build: exclude Documentation from setuptools packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dev = [
 version = { attr = "oscqam.__version__" }
 
 [tool.setuptools.packages.find]
-exclude = ["tests*"]
+exclude = ["tests*", "Documentation"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
Exclude the `Documentation/` directory from setuptools package discovery alongside `tests*`.

This prevents the Documentation directory (which contains .rst files, not Python code) from being included in the package distribution.