### PR TITLE
ci: accept v-prefixed version tags in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,13 @@ on:
   push:
     tags:
       # Version tags: 2.0.2, 2.1.0, optionally with a pre-release suffix
-      # (2.1.0rc1). The project tags without a "v" prefix.
+      # (2.1.0rc1). Historical tags in this repo use a "v" prefix
+      # (v0.23.0), so both forms are accepted; the version check below
+      # strips the prefix before comparing.
       - '[0-9]+.[0-9]+.[0-9]+'
       - '[0-9]+.[0-9]+.[0-9]+*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
 
 permissions:
   contents: read
@@ -29,7 +33,8 @@ jobs:
       - name: Verify tag matches package version
         run: |
           pkg="$(sed -n 's/^__version__ = "\(.*\)"/\1/p' oscqam/__init__.py)"
-          if [ "$pkg" != "$GITHUB_REF_NAME" ]; then
+          ver="${GITHUB_REF_NAME#v}"
+          if [ "$pkg" != "$ver" ]; then
             echo "::error::tag '$GITHUB_REF_NAME' != oscqam.__version__ '$pkg'"
             exit 1
           fi
@@ -42,6 +47,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: >-
           gh release create "$GITHUB_REF_NAME"
-          --title "$GITHUB_REF_NAME"
+          --title "${GITHUB_REF_NAME#v}"
           --generate-notes
           dist/*


### PR DESCRIPTION
The tag→release workflow added in #43 (ported from repose) only fires on unprefixed version tags (`1.2.0`), but every existing tag in this repo is v-prefixed (`v0.23.0`, ..., plus the typo `v.0.12.0`). If the next release is tagged `v1.2.0` following repo tradition, the workflow silently never runs.

- Accept both `1.2.0` and `v1.2.0` tag forms in the trigger globs
- Strip the optional `v` before comparing against `oscqam.__version__`
- Title the GitHub release with the plain version

Note: repose upstream has the same latent mismatch (its own tags are v-prefixed, e.g. `v0.23.1`, while its globs are unprefixed-only) — may be worth the same fix there.

ai-assisted.
