### PR TITLE
docs: align user and developer docs with current CLI and tooling

### DIFF
--- a/Documentation/bugs.rst
+++ b/Documentation/bugs.rst
@@ -1,25 +1,12 @@
-.. _workarounds:
-
 Known bugs & workarounds
 ========================
 
-This page will list known bugs and (if required) possible workarounds for the
+This page lists known bugs and, where required, possible workarounds for the
 problem.
 
-1. No readline support
-----------------------
+There are currently no known issues that require a workaround. Bugs can be
+reported on GitHub (https://github.com/openSUSE/osc-plugin-qam/issues) or via
+`bugzilla`_ by setting the product to ``SUSE Tools`` and choosing the component
+``oscqam``.
 
-The fact that the interactive mode is currently not using the
-``readline``-module is known and (unfortunately), because of some changes that
-``osc`` has made.
-
-To allow ``readline``-like functionality it is possible to use rlwrap_
-with the plugin as a current workaround:
-
-After installing rlwrap the following command will restore readline functionality:
-
-.. code-block:: bash
-
-          rlwrap osc --apiurl=https://api.suse.de/ qam
-
-.. _rlwrap: https://github.com/hanslub42/rlwrap
+.. _bugzilla: https://bugzilla.suse.com

--- a/Documentation/devel.rst
+++ b/Documentation/devel.rst
@@ -4,16 +4,24 @@ Development
 Hosting
 -------
 
-The plugin is hosted on our internal ``gitlab`` instance:
-https://gitlab.suse.de/qa-maintenance/qam-oscplugin
+The plugin is hosted on GitHub:
+https://github.com/openSUSE/osc-plugin-qam (default branch ``master``).
 
 Working from source
 -------------------
 
-After checking out the source code it is required to setup the plugin, so
-``osc`` can find and use it.
+Clone the repository and install the project's dependencies with uv_ (this
+matches CI):
 
-By default ``osc`` will look in the following paths for plugins:
+.. code-block:: bash
+
+          git clone https://github.com/openSUSE/osc-plugin-qam.git
+          cd osc-plugin-qam
+          uv sync --locked
+
+To run the plugin the way a user does, ``osc`` needs to discover it on its
+plugin path. By default ``osc`` scans the following directories for modules
+defining ``OscCommand`` subclasses:
 
 - ``/usr/lib/osc-plugins``
 
@@ -23,46 +31,33 @@ By default ``osc`` will look in the following paths for plugins:
 
 - ``~/.osc-plugins``
 
-To make ``oscqam`` available to ``osc`` the start-up point needs to be
-available in one of these paths and the modules from oscqam need to be
-importable.
-
-An easy way is to symlink the ``oscqam`` folder and ``cli.py`` file into
-e.g. ``~/.osc-plugins`` and set the ``PYTHONPATH`` to include this folder:
-
-.. note::
-
-   To make usage of the ``development`` version easier, while also having a
-   version from the repository installed, it makes sense to add the
-   ``PYTHONPATH`` change to your ``.{bash,zsh}rc``.  To return to the
-   installed version just remove the symbolic links.
-
-.. code-block:: bash
-
-                git clone gitlab@gitlab.suse.de:qa-maintenance/qam-oscplugin.git
-                ln -s "$PWD/oscqam/cli.py" ~/.osc-plugins/oscqam/cli.py
-                ln -s "$PWD/oscqam/oscqam" ~/.osc-plugin/oscqam
-                export PYTHONPATH="~/.osc-plugins:$PYTHONPATH"
+Make the ``oscqam`` package and the ``cli.py`` entry point importable from one
+of these paths (for example by symlinking them into ``~/.osc-plugins``), then
+run ``osc qam --help``.
 
 Testing
 -------
 
-The oscqam plugin uses pytest_ library to run the test. To setup the project
-correctly for usage with it, install it using pip:
+The oscqam plugin uses pytest_ to run the tests, driven through the project's
+``make`` targets:
 
 .. code-block:: bash
 
-          cd <src_directory_oscqam>
-          pip install --user -e .
+          make only-test          # uv run pytest
+          make test-with-coverage # pytest with coverage + reports
+          make checkstyle         # ruff format --check + ruff check
+          make typecheck          # ty check
+          make docs               # sphinx-build -W
+          make test               # only-test + checkstyle + typecheck + docs
 
-Now running the tests with ``py.test`` should work:
+To focus a single test:
 
 .. code-block:: bash
 
-          cd <src_directory_oscqam>
-          py.test ./tests
+          uv run pytest tests/test_model.py::test_name
 
 
+.. _uv: https://docs.astral.sh/uv/
 .. _pytest: http://pytest.org/
 
 Release
@@ -88,45 +83,13 @@ Creating a matching version tag will automatically trigger the GitHub release wo
 
 Note: the RPM package itself is still built and released via the internal IBS in ``QA:Maintenance`` (python-oscqam).
 
-Using a virtual environment
----------------------------
+Virtual environment
+-------------------
 
-To process to setup a virtual environment for the plugin is a little more
-involved than or other projects due to dependencies of `osc`.
-
-The process is as follows:
-
-- Install development headers for `python`, `openssl` and `libcurl`:
-
-.. code:: bash
-
-   sudo zypper in python-devel openssl-devel libcurl-devel
-
-- Create the virtualenvironment and switch to it.
-
-- Install the dependencies for `osc`: when installing `pycurl` make sure to set
-  `PYCURL_SSL_LIBRARY=openssl` otherwise the installation of `urlgrabber` will
-  fail.
-
-.. code:: bash
-
-   pip install pycurl urlgrabber
-
-- Install the osc version referenced by this repository:
-
-.. code:: bash
-
-   git submodule init
-
-   git submodule update
-
-   pip install ./osc
-
-- Install this project into the virtualenvironment:
-
-.. code:: bash
-
-   pip install -e .
+``uv sync --locked`` creates and manages a project-local virtual environment
+under ``.venv`` containing ``osc`` and every other dependency. Prefix commands
+with ``uv run`` (as the ``make`` targets do) to execute them inside it, or run
+``uv run osc qam --help`` to exercise the plugin from the checkout.
 
 Bug reporting
 -------------

--- a/Documentation/todo.rst
+++ b/Documentation/todo.rst
@@ -1,42 +1,8 @@
 Todo
 ====
 
-This little section documents known issues or outstanding features requests
-that should be addressed in the future:
+This section documents known issues or outstanding feature requests that should
+be addressed in the future.
 
-1. Readline support
--------------------
-
-   Currently not possible for multiple reasons:
-
-   ``osc`` includes an outdated replacement for the ``cmd`` module that breaks
-   readline functionality (https://github.com/trentm/cmdln/issues/1).
-
-   .. note::
-      This has been fixed in the osc-upstream project on github.
-      As soon as a release occurred this part of the problem is solved.
-
-   Moreover ``osc`` replaces the ``stdout`` and ``stderr`` file-descriptor
-   with a unicode aware wrapper-object.
-   Even when the fixes to the ``cmd`` replacement are made, this wrapper still
-   prevents ``readline`` from working.
-
-   .. note::
-      It is possible to just replace the wrapper descriptors with the original
-      ones to allow readline support.
-      However this might lead to problems, as osc probably did not include the
-      wrapper object just for fun.
-
-2. openSUSE support
--------------------
-
-   The openSUSE build service uses a different template format that needs some
-   adjustments in ``models.py``.
-
-3. Change to server-side unassign
----------------------------------
-
-   As soon as the ``unassign`` action is implemented server-side this logic
-   should be used. Once this is changed all the code to best-guess the group
-   the user was reviewing for should also be purged from the ``Request``
-   class.
+There are currently no tracked items here. Outstanding work is tracked as issues
+on GitHub: https://github.com/openSUSE/osc-plugin-qam/issues

--- a/README.rst
+++ b/README.rst
@@ -9,15 +9,17 @@ Getting started
 Overview
 --------
 
-The plugin provides the following new features:
+The plugin provides the following features:
 
-- a new subshell that can be started via ``osc qam`` that only accepts the new
-  commands of this plugin.
+- a family of ``osc qam <subcommand>`` commands that drive the QA-Maintenance
+  review workflow (assigning, signing off, approving and rejecting maintenance
+  requests) on top of osc's request/review API.
 
-- it adds command to help with the update workflow.
+- helpers to list, filter and inspect the requests that are open, assigned to a
+  group, or assigned to you.
 
-- to see a list of provided commands use ``osc qam help`` and to see what each
-  command does just use ``osc qam help <command>``.
+- to see the list of provided commands use ``osc qam --help`` and to see what a
+  specific command does use ``osc qam <command> --help``.
 
 For detailed information about common use cases see the :ref:`workflows`.
 
@@ -63,27 +65,72 @@ qam``.
       [general]
       apiurl = https://api.suse.de
 
-Running the command without any further arguments will start an interactive
-session.
-
-.. note::
-
-   When you are running a older version of ``osc`` (e.g. 0.148) then the
-   readline-support is not working out-of-the-box. Please see
-   :ref:`workarounds` to see how to still get it working.
-
-Instead of running the commands in the interactive session it is also possible
-to just write out the complete command following the osc qam part:
-
-The interactive command sequence to list open requests:
-
-.. code-block:: bash
-
-          osc qam
-          osc-qam> list
-
-The single command to list open requests:
+Every action is a subcommand of ``osc qam``. For example, to list the open
+requests:
 
 .. code-block:: bash
 
           osc qam list
+
+Commands
+--------
+
+The plugin adds the following subcommands. Pass ``--help`` to any of them for
+the full list of options (e.g. ``osc qam assign --help``).
+
+Listing and inspecting requests
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- ``list`` (alias ``open``) — list requests that are open for review. Filter
+  with ``-G/--group`` (repeatable) and ``-U/--user``.
+
+- ``assigned`` — list requests that already have assigned reviews. Filter with
+  ``-G/--group`` (repeatable) and ``-U/--user``.
+
+- ``my`` — list the requests currently assigned to you (shortcut for
+  ``osc qam assigned -U <your-user>``).
+
+- ``info`` — show detailed information for a single ``request_id``.
+
+  All four commands share the display options ``-F/--fields`` (repeatable,
+  choose the columns to output), ``-T/--tabular`` (render as an ASCII table),
+  and ``-V/--describe-fields`` (print the available fields).
+
+Working with requests
+~~~~~~~~~~~~~~~~~~~~~~~
+
+- ``assign`` — assign a request to a user. Options: ``-U/--user``,
+  ``-G/--group`` (repeatable), ``--skip-template`` (do not check that a test
+  report template exists).
+
+- ``unassign`` — remove an assignment. Options: ``-U/--user``, ``-G/--group``
+  (repeatable).
+
+- ``approve`` — sign off / approve a request. Options: ``-G/--group`` (directly
+  approve for a group that does not need reviews), ``--skip-template``.
+
+- ``reject`` — reject a request. Options: ``-U/--user``, ``-M/--message``,
+  ``-R/--reason`` (repeatable), ``--skip-template``.
+
+Comments
+~~~~~~~~
+
+- ``comment`` — add a comment to a request (``comment <request_id> "<text>"``).
+
+- ``deletecomment`` (alias ``rmcomment``) — remove one of your own comments from
+  a request.
+
+Miscellaneous
+~~~~~~~~~~~~~~
+
+- ``version`` — print the plugin version.
+
+SLFO and staging requests
+-------------------------
+
+SLFO requests are handled through the same request/review API as classic
+OBS/IBS requests. Two behaviours are specific to them: for staging requests the
+test report id (RRID) is derived from the request's **target** project (for
+example ``SUSE:SLFO:1.1``) rather than the source project, while PI releases map
+a ``SUSE:SLFO:...`` source to ``SUSE:PI:<version>``; and bug collection is
+skipped for SLFO requests.


### PR DESCRIPTION
## Summary

Brings the documentation in line with the current state of the plugin. The docs previously described a defunct interactive \`osc-qam>\` subshell, omitted every command and option the plugin provides, and pointed developers at internal GitLab + \`pip\`/submodule setup.

## Changes

- **README.rst / install.rst** (install.rst is a symlink to README.rst):
  - Overview and Usage describe the flat \`osc qam <subcommand>\` interface and \`osc qam <command> --help\`; the interactive-subshell narrative, \`osc-qam>\` example and readline \`:ref:workarounds\` note are removed.
  - Added a full **Commands** reference covering every subcommand and its options (\`assign\`, \`unassign\`, \`approve\`, \`reject\`, \`comment\`, \`deletecomment\`/\`rmcomment\`, \`info\`, \`list\`/\`open\`, \`my\`, \`assigned\`, \`version\`; flags \`--skip-template\`, \`-F/--fields\`, \`-T/--tabular\`, \`-V/--describe-fields\`, \`-U/--user\`, \`-M/--message\`, \`-R/--reason\`, \`-G/--group\`).
  - Added an **SLFO and staging requests** section (RRID derived from the target project for staging, \`SUSE:PI:<version>\` mapping for PI releases, bug collection skipped for SLFO).
- **Documentation/devel.rst**: hosting points to GitHub \`openSUSE/osc-plugin-qam\`; source setup uses \`uv sync --locked\` and the \`make\` targets; the GitLab clone, \`pip install -e .\`, \`py.test\`, \`PYTHONPATH\` symlink dance and \`git submodule\` / \`pycurl\` virtualenv procedure are removed.
- **Documentation/bugs.rst**: removed the readline/rlwrap section and the dangling \`.. _workarounds:\` target; points to GitHub issues / Bugzilla.
- **Documentation/todo.rst**: removed obsolete readline and server-side-unassign items.

## Verification

- \`make docs\` (sphinx-build \`-W --keep-going\`): build succeeded with zero warnings.
- No remaining references to \`subshell\`, \`osc-qam>\`, \`readline\`, \`rlwrap\`, or \`:ref:workarounds\` in the source docs.
- No remaining \`gitlab.suse.de\`, \`pip install -e\`, \`py.test\` or \`git submodule\` references in devel.rst.