### PR TITLE
fix: skip MAINT:RejectReason attribute for SLFO/PI rejects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,11 @@
   - special RRID derivation in `Request.src_project_to_rrid` (for staging requests
     the RRID comes from the **target** project such as `SUSE:SLFO:1.1`; for PI
     releases it maps source `SUSE:SLFO:...` to `SUSE:PI:<ver>`);
-  - skipping bug collection for SLFO requests (PI via src starting SUSE:SLFO:* or staging via target SUSE:SLFO:*).
+  - skipping bug collection for SLFO requests (PI via src starting SUSE:SLFO:* or staging via target SUSE:SLFO:*);
+  - skipping the `MAINT:RejectReason` attribute on reject for SLFO requests
+    (guarded by `is_slfo` in `Request.review_decline`) — no maintenance
+    incident exists and the SLFO source project rejects the attribute; the
+    reason stays in the decline comment.
 - The library lives in `oscqam/`; the user-facing entry points are the
   `osc.commandline.OscCommand` subclasses in `oscqam/cli.py` (the `osc qam`
   parent command) and `oscqam/cli_*.py` (one subcommand each, via

--- a/README.rst
+++ b/README.rst
@@ -129,8 +129,11 @@ SLFO and staging requests
 -------------------------
 
 SLFO requests are handled through the same request/review API as classic
-OBS/IBS requests. Two behaviours are specific to them: for staging requests the
+OBS/IBS requests. Three behaviours are specific to them: for staging requests the
 test report id (RRID) is derived from the request's **target** project (for
 example ``SUSE:SLFO:1.1``) rather than the source project, while PI releases map
-a ``SUSE:SLFO:...`` source to ``SUSE:PI:<version>``; and bug collection is
-skipped for SLFO requests.
+a ``SUSE:SLFO:...`` source to ``SUSE:PI:<version>``; bug collection is
+skipped for SLFO requests; and the ``MAINT:RejectReason`` attribute is not
+recorded on reject (there is no maintenance incident to attach it to and the
+SLFO source project rejects it) — the reason is still shown in the decline
+comment.

--- a/oscqam/__init__.py
+++ b/oscqam/__init__.py
@@ -1,3 +1,3 @@
 """OSC-QAM: A command-line tool for interacting with the QAM dashboard."""
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"

--- a/oscqam/models/request.py
+++ b/oscqam/models/request.py
@@ -314,9 +314,15 @@ class Request(osc.core.Request, XmlFactoryMixin):
             reasons: A list of RejectReason objects that
                 explains why the request was declined.
                 The reason will be added as an attribute to the Maintenance
-                incident.
+                incident. For SLFO/PI requests this attribute is skipped
+                (see below); the reason is still carried in the decline
+                comment.
         """
-        if reasons:
+        if reasons and not self.is_slfo:
+            # SLFO requests (PI or staging) have no maintenance incident to
+            # attach the MAINT:RejectReason attribute to, and the SLFO source
+            # project rejects the MAINT namespace (400). Skip it, mirroring the
+            # bug-collection skip; the reason remains in the decline comment.
             reason = self._build_reject_attribute(reasons)
             self.remote.projects.set_attribute(self.src_project, reason)
         comment = self._format_review_comment(comment)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -270,6 +270,31 @@ def test_bugs_skipped_for_slfo_staging(remote):
     assert remote.bugs.for_request(request) == []
 
 
+def test_review_decline_skips_reject_attribute_for_slfo(remote):
+    """SLFO/PI declines must not POST the MAINT:RejectReason attribute: there
+    is no maintenance incident and the SLFO source project rejects it (400).
+    Only the changereviewstate POST should happen."""
+    request = Request.parse(remote, req_slfo_pi)[0]
+    user = remote.users.by_name("anonymous")
+    request.review_decline(user=user, comment="nope", reasons=[RejectReason.retracted])
+    assert len(remote.post_calls) == 1
+    assert "changereviewstate" in remote.post_calls[0]
+    assert "_attribute/MAINT:RejectReason" not in remote.post_calls[0]
+
+
+def test_review_decline_sets_reject_attribute_for_classic(remote):
+    """Classic maintenance declines still record the MAINT:RejectReason
+    attribute on the incident source project (regression guard)."""
+    request = Request.parse(remote, req_1_xml)[0]
+    endpoint = "source/{prj}/_attribute/MAINT:RejectReason".format(
+        prj=request.src_project
+    )
+    remote.register_url(endpoint, lambda: load_fixture("reject_reason_attribute.xml"))
+    user = remote.users.by_name("anonymous")
+    request.review_decline(user=user, comment="nope", reasons=[RejectReason.retracted])
+    assert any(endpoint in call for call in remote.post_calls)
+
+
 def test_template_splits_srcrpms():
     assert create_template().log_entries["SRCRPMs"] == ["glibc", "glibc-devel"]
 


### PR DESCRIPTION
## Problem

Rejecting an SLFO/PI request (e.g. `SUSE:PI:16.0:<reqid>`) fails when the
plugin tries to record the reject reason:

```
osc qam reject -R retracted --skip-template SUSE:PI:16.0:416326
Error accessing https://api.opensuse.org/source/SUSE:SLFO:Products:.../_attribute/MAINT:RejectReason - 400: Bad Request
```

`MAINT:RejectReason` is a maintenance-incident concept. SLFO/PI product
releases have no maintenance incident to attach it to, and the SLFO source
project rejects the `MAINT` namespace outright (400).

## Fix

Guard the attribute write in `Request.review_decline` with `not self.is_slfo`,
mirroring the existing bug-collection skip (`BugRemote.for_request`). The
decline proceeds normally and the reject reason is still carried in the
decline comment, so no information is lost.

## Notes

- The reject-reason attribute has no consumer inside this plugin (it is only
  written for external maintenance tooling); there is no PI/SLFO equivalent
  target, so skipping is the correct behaviour.
- Version bumped to 1.4.0.

## Tests

- `test_review_decline_skips_reject_attribute_for_slfo` — SLFO/PI decline
  posts only `changereviewstate`, never `MAINT:RejectReason`.
- `test_review_decline_sets_reject_attribute_for_classic` — regression guard:
  classic maintenance still records the attribute.

Full gate green locally: `ruff format --check` + `ruff check`, `ty check`,
`sphinx-build -W`, and `pytest` (126 passed, coverage 74%).