### PR TITLE
ci: automate Dependabot updates and auto-merge

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,17 +1,18 @@
+---
 pull_request_rules:
   - name: automatic merge
     conditions:
       - and: &base_checks
-        - base=master
-        - -label~=^acceptance-tests-needed|not-ready
-        - "#check-failure=0"
-        - "#check-pending=0"
-        - linear-history
+          - base=master
+          - -label~=^acceptance-tests-needed|not-ready
+          - "#check-failure=0"
+          - "#check-pending=0"
+          - linear-history
       - and:
-        - "#approved-reviews-by>=1"
-        - "#changes-requested-reviews-by=0"
-        # https://doc.mergify.io/examples.html#require-all-requested-reviews-to-be-approved
-        - "#review-requested=0"
+          - "#approved-reviews-by>=1"
+          - "#changes-requested-reviews-by=0"
+          # https://doc.mergify.io/examples.html#require-all-requested-reviews-to-be-approved
+          - "#review-requested=0"
     actions: &merge
       merge:
         method: merge
@@ -20,3 +21,12 @@ pull_request_rules:
       - and: *base_checks
       - "label=merge-fast"
     actions: *merge
+  - name: automatic merge for dependabot updates
+    conditions:
+      - and: *base_checks
+      - and:
+          - base=master
+          - author=dependabot[bot]
+    actions:
+      merge:
+        method: squash


### PR DESCRIPTION
Motivation:
Automate GHA workflow updates via Dependabot and automatically squash-merge
them when CI passes to eliminate manual maintenance.

Design Choices:
Configured Dependabot for github-actions and added a squash auto-merge
Mergify rule for `dependabot[bot]`. Removed obsolete delayed-merge rules.

Benefits:
Saves maintainer time by fully automating dependency updates with high security
while preserving clean linear git history.